### PR TITLE
[memoization] Memoized dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,25 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [0.2.0] - 202-01-03
+## [0.2.0] - 202-01-05
 ### Changed
 - (Private API (`SmartCore::Container::RegistryBuilder`)) improved semantics:
   - `build_state` is renamed to `initialise`;
   - `build_definitions` is renamed to `define`;
+- (Public API) Support for memoized dependencies (all dependencies are memoized by default)
+  ```ruby
+  class MyContainer < SmartCore::Container
+    namespace(:some_naespace) do
+      # memoized by default
+      register(:random_number) { rand(1000) }
+      # explicit memoization
+      register(:random_number, memoized: true) { rand(1000) }
+
+      # register non-memoizable dependency
+      register(:random_number, memoized: false) { rand(1000) }
+    end
+  end
+  ```
 
 ## [0.1.0] - 2020-01-02
 

--- a/lib/smart_core/container/definition_dsl.rb
+++ b/lib/smart_core/container/definition_dsl.rb
@@ -63,17 +63,19 @@ class SmartCore::Container
       end
 
       # @param dependency_name [String, Symbol]
+      # @option memoize [Boolean]
       # @param dependency_definition [Block]
       # @return [void]
       #
       # @api public
       # @since 0.1.0
-      def register(dependency_name, &dependency_definition)
+      # @version 0.2.0
+      def register(dependency_name, memoize: true, &dependency_definition)
         @__container_definition_lock__.thread_safe do
           DependencyCompatability::Definition.prevent_namespace_overlap!(self, dependency_name)
 
           __container_definition_commands__ << Commands::Definition::Register.new(
-            dependency_name, dependency_definition
+            dependency_name, dependency_definition, memoize
           )
         end
       end

--- a/lib/smart_core/container/definition_dsl/commands/definition/register.rb
+++ b/lib/smart_core/container/definition_dsl/commands/definition/register.rb
@@ -15,14 +15,17 @@ module SmartCore::Container::DefinitionDSL::Commands::Definition
 
     # @param dependency_name [String, Symbol]
     # @param dependency_definition [Proc]
+    # @param memoize [Boolean]
     # @return [void]
     #
     # @api private
     # @since 0.1.0
-    def initialize(dependency_name, dependency_definition)
+    # @version 0.2.0
+    def initialize(dependency_name, dependency_definition, memoize)
       SmartCore::Container::KeyGuard.indifferently_accessable_key(dependency_name).tap do |name|
         @dependency_name = name
         @dependency_definition = dependency_definition
+        @memoize = memoize
       end
     end
 
@@ -31,16 +34,18 @@ module SmartCore::Container::DefinitionDSL::Commands::Definition
     #
     # @api private
     # @since 0.1.0
+    # @version 0.2.0
     def call(registry)
-      registry.register_dependency(dependency_name, &dependency_definition)
+      registry.register_dependency(dependency_name, memoize, &dependency_definition)
     end
 
     # @return [SmartCore::Container::DefinitionDSL::Commands::Definition::Register]
     #
     # @api private
     # @since 0.1.0
+    # @version 0.2.0
     def dup
-      self.class.new(dependency_name, dependency_definition)
+      self.class.new(dependency_name, dependency_definition, memoize)
     end
 
     private
@@ -50,5 +55,11 @@ module SmartCore::Container::DefinitionDSL::Commands::Definition
     # @api private
     # @since 0.1.0
     attr_reader :dependency_definition
+
+    # @return [Boolean]
+    #
+    # @api private
+    # @since 0.2.0
+    attr_reader :memoize
   end
 end

--- a/lib/smart_core/container/entities.rb
+++ b/lib/smart_core/container/entities.rb
@@ -5,6 +5,7 @@
 module SmartCore::Container::Entities
   require_relative 'entities/base'
   require_relative 'entities/dependency'
+  require_relative 'entities/memoized_dependency'
   require_relative 'entities/dependency_builder'
   require_relative 'entities/namespace'
   require_relative 'entities/namespace_builder'

--- a/lib/smart_core/container/entities/dependency_builder.rb
+++ b/lib/smart_core/container/entities/dependency_builder.rb
@@ -6,32 +6,38 @@ class SmartCore::Container::Entities::DependencyBuilder
   class << self
     # @param dependency_name [String]
     # @param dependency_definition [Proc]
+    # @param memoize [Boolean]
     # @return [SmartCore::Container::Entities::Dependency]
     #
     # @api private
     # @since 0.1.0
-    def build(dependency_name, dependency_definition)
-      new(dependency_name, dependency_definition).build
+    # @version 0.2.0
+    def build(dependency_name, dependency_definition, memoize)
+      new(dependency_name, dependency_definition, memoize).build
     end
   end
 
   # @param dependency_name [String]
   # @param dependency_definition [Proc]
+  # @param memoize [Boolean]
   # @return [void]
   #
   # @api private
   # @since 0.1.0
-  def initialize(dependency_name, dependency_definition)
+  # @version 0.2.0
+  def initialize(dependency_name, dependency_definition, memoize)
     @dependency_name = dependency_name
     @dependency_definition = dependency_definition
+    @memoize = memoize
   end
 
   # @return [SmartCore::Container::Entities::Dependency]
   #
   # @api private
   # @since 0.1.0
+  # @version 0.2.0
   def build
-    SmartCore::Container::Entities::Dependency.new(dependency_name, dependency_definition)
+    memoize ? build_memoized_dependency : build_original_dependency
   end
 
   private
@@ -47,4 +53,26 @@ class SmartCore::Container::Entities::DependencyBuilder
   # @api private
   # @since 0.1.0
   attr_reader :dependency_definition
+
+  # @return [Boolean]
+  #
+  # @api private
+  # @since 0.2.0
+  attr_reader :memoize
+
+  # @return [SmartCore::Container::Entities::Dependency]
+  #
+  # @api private
+  # @since 0.2.0
+  def build_memoized_dependency
+    SmartCore::Container::Entities::MemoizedDependency.new(dependency_name, dependency_definition)
+  end
+
+  # @return [SmartCore::Container::Entities::Dependency]
+  #
+  # @api private
+  # @since 0.2.0
+  def build_original_dependency
+    SmartCore::Container::Entities::Dependency.new(dependency_name, dependency_definition)
+  end
 end

--- a/lib/smart_core/container/entities/memoized_dependency.rb
+++ b/lib/smart_core/container/entities/memoized_dependency.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module SmartCore::Container::Entities
+  # @api private
+  # @since 0.2.0
+  class MemoizedDependency < Dependency
+    # @param dependency_name [String]
+    # @param dependency_definition [Proc]
+    # @return [void]
+    #
+    # @api private
+    # @since 0.2.0
+    def initialize(dependency_name, dependency_definition)
+      super(dependency_name, dependency_definition)
+      @lock = SmartCore::Container::ArbitaryLock.new
+    end
+
+    # @return [Any]
+    #
+    # @api private
+    # @since 0.2.0
+    def reveal
+      @lock.thread_safe do
+        unless instance_variable_defined?(:@revealed_dependency)
+          @revealed_dependency = dependency_definition.call
+        else
+          @revealed_dependency
+        end
+      end
+    end
+
+    private
+
+    # @return [Proc]
+    #
+    # @api private
+    # @since 0.2.0
+    attr_reader :dependency_definition
+  end
+end

--- a/lib/smart_core/container/registry.rb
+++ b/lib/smart_core/container/registry.rb
@@ -32,13 +32,15 @@ class SmartCore::Container::Registry
   end
 
   # @param name [String, Symbol]
+  # @param memoize [Boolean]
   # @param dependency_definition [Block]
   # @return [void]
   #
   # @api private
   # @since 0.1.0
-  def register_dependency(name, &dependency_definition)
-    thread_safe { add_dependency(name, dependency_definition) }
+  # @version 0.2.0
+  def register_dependency(name, memoize = true, &dependency_definition)
+    thread_safe { add_dependency(name, dependency_definition, memoize) }
   end
 
   # @param name [String, Symbol]
@@ -157,13 +159,15 @@ class SmartCore::Container::Registry
 
   # @param dependency_name [String, Symbol]
   # @param dependency_definition [Proc]
+  # @param memoize [Boolean]
   # @return [SmartCore::Container::Entities::Dependency]
   #
   # @raise [SmartCore::Container::DependencyOverNamespaceOverlapError]
   #
   # @api private
   # @since 0.1.0
-  def add_dependency(dependency_name, dependency_definition)
+  # @version 0.2.0
+  def add_dependency(dependency_name, dependency_definition, memoize)
     if state_frozen?
       raise(SmartCore::Container::FrozenRegistryError, 'Can not modify frozen registry!')
     end
@@ -171,7 +175,7 @@ class SmartCore::Container::Registry
     prevent_namespace_overlap!(dependency_name)
 
     dependency_entity = SmartCore::Container::Entities::DependencyBuilder.build(
-      dependency_name, dependency_definition
+      dependency_name, dependency_definition, memoize
     )
 
     dependency_entity.tap { registry[dependency_name] = dependency_entity }

--- a/spec/features/hash_tree_spec.rb
+++ b/spec/features/hash_tree_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe 'Hash tree (#to_h / #to_hash / #hash_tree)' do
       end
 
       namespace(:queues) do
-        register(:async) { :sidekiq }
-        register(:sync) { :in_memory }
+        register(:async, memoize: false) { :sidekiq }
+        register(:sync, memoize: false) { :in_memory }
       end
     end.new
   end
@@ -43,10 +43,10 @@ RSpec.describe 'Hash tree (#to_h / #to_hash / #hash_tree)' do
         expect(container.public_send(method_name)).to match(
           'storages' => {
             'adapters' => {
-              'database' => an_instance_of(SmartCore::Container::Entities::Dependency),
-              'cache' => an_instance_of(SmartCore::Container::Entities::Dependency)
+              'database' => an_instance_of(SmartCore::Container::Entities::MemoizedDependency),
+              'cache' => an_instance_of(SmartCore::Container::Entities::MemoizedDependency)
             },
-            'logger' => an_instance_of(SmartCore::Container::Entities::Dependency)
+            'logger' => an_instance_of(SmartCore::Container::Entities::MemoizedDependency)
           },
           'queues' => {
             'async' => an_instance_of(SmartCore::Container::Entities::Dependency),

--- a/spec/features/memoization_spec.rb
+++ b/spec/features/memoization_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Memoization (dependency memoization)' do
+  specify 'all dependencies are memoized by default' do
+    container = Class.new(SmartCore::Container) do
+      namespace(:deps) do
+        register(:sidekiq) { Object.new }
+      end
+    end.new
+
+    first_resolve  = container['deps.sidekiq']
+    second_resolve = container['deps.sidekiq']
+
+    expect(first_resolve.object_id).to eq(second_resolve.object_id)
+  end
+
+  specify 'explicit memoization boolean flag (memoize or not)' do
+    container = Class.new(SmartCore::Container) do
+      namespace(:memoized_deps) do
+        # explicitly memoized
+        register(:sidekiq, memoize: true) { Object.new }
+
+        # implicitly memoized
+        register(:sneakers) { Object.new }
+      end
+
+      namespace(:nonmemoized_deps) do
+        register(:resque, memoize: false) { Object.new }
+      end
+    end.new
+
+    # memoized dependencies
+    expect(container['memoized_deps.sidekiq']).to eq(container['memoized_deps.sidekiq'])
+    expect(container['memoized_deps.sneakers']).to eq(container['memoized_deps.sneakers'])
+
+    first_non_memo_resolve  = container['nonmemoized_deps.resque']
+    second_non_memo_resolve = container['nonmemoized_deps.resque']
+
+    # nonmemoized dependency
+    expect(first_non_memo_resolve.object_id).not_to eq(second_non_memo_resolve.object_id)
+  end
+end


### PR DESCRIPTION
- all dependencies are memoized by default;
- you can explicitly mark any dependencies as non-memoizable (`memoize: false`)

```ruby
class MyContainer < SmartCore::Container
  register(:random_number) { rand(1000) } # memoized by default
  register(:random_float, memoize: false)) { rand(0.0..1.0)  } # non-memoizable dependency
end

container = MyContainer.new

container['random_number'] # => 473
container['random_number'] # => 473 (memoized)

container['random_float'] # => 0.31813332477605105
container['random_float'] # => 0.6299141655140369 (non-memoized)
```